### PR TITLE
Fix Streaming Error in examples/helloworld

### DIFF
--- a/examples/helloworld/__main__.py
+++ b/examples/helloworld/__main__.py
@@ -27,7 +27,9 @@ if __name__ == '__main__':
         version='1.0.0',
         defaultInputModes=['text'],
         defaultOutputModes=['text'],
-        capabilities=AgentCapabilities(),
+        capabilities=AgentCapabilities(
+            streaming=True,  # enable streaming mode
+        ),
         skills=[skill],
         authentication=AgentAuthentication(schemes=['public']),
     )

--- a/examples/helloworld/test_client.py
+++ b/examples/helloworld/test_client.py
@@ -34,6 +34,7 @@ async def main() -> None:
             params=MessageSendParams(**send_message_payload)
         )
 
+        # if you want to stream the response, please make sure to set streaming=True in the agent card (__main__.py)
         stream_response = client.send_message_streaming(streaming_request)
         async for chunk in stream_response:
             print(chunk.model_dump(mode='json', exclude_none=True))


### PR DESCRIPTION
This PR addresses an issue where running the examples/helloworld example results in a streaming-related error. The changes ensure a smoother developer experience when executing the helloworld example by:

1. **Enabling Streaming Mode in Agent Card**: Updated the Agent Card in the examples/helloworld directory to explicitly enable streaming mode, resolving the error encountered during execution.
2. **Adding Comments in Test Client**: Added clarifying comments to the test_client.py script to guide developers on the expected behavior and configuration when running the helloworld example.

- [O] Follow the [`CONTRIBUTING` Guide](https://github.com/google/a2a-python/blob/main/CONTRIBUTING.md).
- [O] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [O] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [O] Appropriate docs were updated (if necessary)