### PR TITLE
fix: Handle reusing queue on task events

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -195,8 +195,10 @@ class DefaultRequestHandler(RequestHandler):
             consumer = EventConsumer(queue)
             producer_task.add_done_callback(consumer.agent_task_callback)
             async for event in result_aggregator.consume_and_emit(consumer):
-                # Now we know we have a Task, register the queue
-                if isinstance(event, Task):
+                if isinstance(event, Task) and task_id != event.id:
+                    logger.warning(
+                        f'Agent generated task_id={event.id} does not match the RequestContext task_id={task_id}.'
+                    )
                     try:
                         await self._queue_manager.add(event.id, queue)
                         task_id = event.id


### PR DESCRIPTION
During streaming, a queue is setup with a default task_id. If an agent returns task objects with the same task_id, we will reuse the default queue.

If a new task_id is returned from the agent, we will log this as warning and create a new queue for the provided task object.