### PR TITLE
feat: Update to support python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A2A Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 keywords = ["A2A", "A2A SDK", "A2A Protocol", "Agent2Agent"]
 dependencies = [
     "httpx>=0.28.1",
@@ -22,7 +22,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: Apache Software License",

--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 
 from collections.abc import AsyncGenerator
 
@@ -14,6 +15,12 @@ from a2a.types import (
 from a2a.utils.errors import ServerError
 from a2a.utils.telemetry import SpanKind, trace_class
 
+# This is an alias to the execption for closed queue
+QueueClosed = asyncio.QueueEmpty
+
+# When using python 3.13 or higher, the closed queue signal is QueueShutdown
+if sys.version_info >= (3, 13):
+    QueueClosed = asyncio.QueueShutDown
 
 logger = logging.getLogger(__name__)
 
@@ -111,13 +118,16 @@ class EventConsumer:
 
                 if is_final_event:
                     logger.debug('Stopping event consumption in consume_all.')
-                    self.queue.close()
+                    await self.queue.close()
                     break
             except TimeoutError:
                 # continue polling until there is a final event
                 continue
-            except asyncio.QueueShutDown:
-                break
+            except QueueClosed:
+                # Confirm that the queue is closed, e.g. we aren't on
+                # python 3.12 and get a queue empty error on an open queue
+                if self.queue.is_closed():
+                    break
 
     def agent_task_callback(self, agent_task: asyncio.Task[None]):
         """Callback to handle exceptions from the agent's execution task.

--- a/src/a2a/server/events/in_memory_queue_manager.py
+++ b/src/a2a/server/events/in_memory_queue_manager.py
@@ -69,7 +69,7 @@ class InMemoryQueueManager(QueueManager):
             if task_id not in self._task_queue:
                 raise NoTaskQueue()
             queue = self._task_queue.pop(task_id)
-            queue.close()
+            await queue.close()
 
     async def create_or_tap(self, task_id: str) -> EventQueue:
         """Creates a new event queue for a task ID if one doesn't exist, otherwise taps the existing one.

--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -147,7 +147,7 @@ class DefaultRequestHandler(RequestHandler):
             queue: The event queue for the agent to publish to.
         """
         await self.agent_executor.execute(request, queue)
-        queue.close()
+        await queue.close()
 
     async def on_message_send(
         self, params: MessageSendParams


### PR DESCRIPTION
- add case statement to use the asyncio.Queue.shutdown method for 3.13+
- add special handling to allow for similar semantics as asyncio.Queue.shutdown for 3.12

Tested on multiple samples in the a2a repo and some examples in this repo
