### PR TITLE
Fix: fix hello world example for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,14 @@ classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+<<<<<<< HEAD
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+=======
+  "Programming Language :: Python :: 3.12",
+>>>>>>> 8ec734c (feat: Update to support python 3.12)
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-<<<<<<< HEAD
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-=======
-  "Programming Language :: Python :: 3.12",
->>>>>>> 8ec734c (feat: Update to support python 3.12)
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: Apache Software License",

--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -15,6 +15,12 @@ from a2a.types import (
 from a2a.utils.errors import ServerError
 from a2a.utils.telemetry import SpanKind, trace_class
 
+# This is an alias to the execption for closed queue
+QueueClosed = asyncio.QueueEmpty
+
+# When using python 3.13 or higher, the closed queue signal is QueueShutdown
+if sys.version_info >= (3, 13):
+    QueueClosed = asyncio.QueueShutDown
 
 # This is an alias to the exception for closed queue
 QueueClosed = asyncio.QueueEmpty

--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -15,14 +15,8 @@ from a2a.types import (
 from a2a.utils.errors import ServerError
 from a2a.utils.telemetry import SpanKind, trace_class
 
+
 # This is an alias to the execption for closed queue
-QueueClosed = asyncio.QueueEmpty
-
-# When using python 3.13 or higher, the closed queue signal is QueueShutdown
-if sys.version_info >= (3, 13):
-    QueueClosed = asyncio.QueueShutDown
-
-# This is an alias to the exception for closed queue
 QueueClosed = asyncio.QueueEmpty
 
 # When using python 3.13 or higher, the closed queue signal is QueueShutdown

--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -16,7 +16,7 @@ from a2a.utils.errors import ServerError
 from a2a.utils.telemetry import SpanKind, trace_class
 
 
-# This is an alias to the execption for closed queue
+# This is an alias to the exception for closed queue
 QueueClosed = asyncio.QueueEmpty
 
 # When using python 3.13 or higher, the closed queue signal is QueueShutdown

--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -101,7 +101,6 @@ class EventConsumer:
                 logger.debug(
                     f'Dequeued event of type: {type(event)} in consume_all.'
                 )
-                yield event
                 self.queue.task_done()
                 logger.debug(
                     'Marked task as done in event queue in consume_all'
@@ -123,10 +122,16 @@ class EventConsumer:
                     )
                 )
 
+                # Make sure the yield is after the close events, otherwise
+                # the caller may end up in a blocked state where this
+                # generator isn't called again to close things out and the
+                # other part is waiting for an event or a closed queue.
                 if is_final_event:
                     logger.debug('Stopping event consumption in consume_all.')
                     await self.queue.close()
+                    yield event
                     break
+                yield event
             except TimeoutError:
                 # continue polling until there is a final event
                 continue


### PR DESCRIPTION
There was a race condition based on when the generator yielded with respect to when the queue was closed.
