### PR TITLE
chore: switch to debug level in task save and delete

### DIFF
--- a/src/a2a/server/tasks/inmemory_task_store.py
+++ b/src/a2a/server/tasks/inmemory_task_store.py
@@ -25,7 +25,7 @@ class InMemoryTaskStore(TaskStore):
         """Saves or updates a task in the in-memory store."""
         async with self.lock:
             self.tasks[task.id] = task
-            logger.info('Task %s saved successfully.', task.id)
+            logger.debug('Task %s saved successfully.', task.id)
 
     async def get(self, task_id: str) -> Task | None:
         """Retrieves a task from the in-memory store by ID."""
@@ -44,7 +44,7 @@ class InMemoryTaskStore(TaskStore):
             logger.debug('Attempting to delete task with id: %s', task_id)
             if task_id in self.tasks:
                 del self.tasks[task_id]
-                logger.info('Task %s deleted successfully.', task_id)
+                logger.debug('Task %s deleted successfully.', task_id)
             else:
                 logger.warning(
                     'Attempted to delete nonexistent task with id: %s', task_id


### PR DESCRIPTION
# Description

This PR changes the log level in `InMemoryTaskStore` `save` and `delete` methods from `info` to `debug`.
Otherwise too many logs are being generated:

```
[...]
2025-05-26 11:20:27,891 INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
2025-05-26 11:20:27,892 INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
2025-05-26 11:20:27,893 INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
2025-05-26 11:20:27,893INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
2025-05-26 11:20:27,894 INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
2025-05-26 11:20:27,894 INFO:	a2a.server.tasks.inmemory_task_store:28 Task 918d2029-8849-4cc9-ab7a-402919cf427b saved successfully.
[...]
```
